### PR TITLE
Fix pluralization of '1 commits'

### DIFF
--- a/web/elm/CommitList/Header/View.elm
+++ b/web/elm/CommitList/Header/View.elm
@@ -19,9 +19,10 @@ view model =
         if totalCount == 0 then
             Shared.CompletedBadge.view "review"
         else
+            calculatedReviewableCount = reviewableCount model
             p [ class "left-to-review" ]
-                [ strong [] [ number <| reviewableCount model ]
-                , text " commits to review: "
+                [ strong [] [ number <| calculatedReviewableCount ]
+                , text " " ++ (pluralize calculatedReviewableCount "commit" "commits") ++ " to review: "
                 , strong [] [ number <| reviewableByOthersCount model ]
                 , text " by others, "
                 , strong [] [ number <| reviewableByYouCount model ]
@@ -45,6 +46,9 @@ renderOldestReviewableCommitLink model =
     else
         div [] []
 
+pluralize : Int -> String -> String -> String
+pluralize count singularString pluralString =
+    if count == 1 then singularString else pluralString
 
 number : Int -> Node a
 number n =


### PR DESCRIPTION
Couldn't spare the time right now to run tests or regenerate JS from elm if that's a thing. Will look again on the next lab…

- [ ] Run tests, should pass
- [ ] Add tests?
- [ ] Regenerate JS from Elm? Is that a thing?